### PR TITLE
add functionality to load templates by aliased name in config file

### DIFF
--- a/bin/moleculer.js
+++ b/bin/moleculer.js
@@ -8,7 +8,7 @@
 const updateNotifier = require("update-notifier");
 const pkg = require("../package.json");
 
-updateNotifier({pkg}).notify();
+updateNotifier({ pkg }).notify();
 
 console.log();
 process.on("exit", function () {
@@ -22,5 +22,6 @@ require("yargs")
 	.command(require("./../src/start"))
 	.command(require("./../src/create"))
 	.command(require("./../src/connect"))
+	.command(require("./../src/alias-template"))
 	.help()
 	.argv;

--- a/src/alias-template/index.js
+++ b/src/alias-template/index.js
@@ -1,0 +1,75 @@
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+const inquirer = require("inquirer");
+const chalk = require("chalk");
+const { fail } = require("../utils");
+
+/**
+ * Yargs command
+ */
+module.exports = {
+	command: "alias-template <template-name> <template-url>",
+	describe: "Alias a template url by name for usage in moleculer-cli init command.",
+	handler: handler
+};
+
+let values = {
+	aliasedTemplates: {}
+}
+
+/**
+ * Handler for yards command
+ *
+ * @param {any} opts
+ */
+function handler(opts) {
+	Object.assign(values, opts);
+
+	const configPath = path.join(os.homedir(), '.moleculer-templates.json');
+	return (
+		Promise.resolve()
+			//check for existing template alias config file
+			.then(() => {
+				return new Promise((resolve, reject) => {
+					fs.exists(configPath, exists => {
+						if (exists) {
+							fs.readFile(configPath, (err, config) => {
+								if (err) {
+									reject();
+								}
+								values.aliasedTemplates = JSON.parse(config);
+								resolve();
+							});
+						} else {
+							resolve();
+						}
+					});
+				});
+			})
+			// check if template name already exists
+			.then(() => {
+				const { templateName, aliasedTemplates } = values;
+				if (aliasedTemplates[templateName]) {
+					// if exists ask for overwrite
+					return inquirer.prompt([{
+						type: "confirm",
+						name: "continue",
+						message: chalk.yellow.bold(`The alias '${templateName}' already exists with value '${aliasedTemplates[templateName]}'! Overwrite?`),
+						default: false
+					}]).then(answers => {
+						if (!answers.continue)
+							process.exit(0);
+					});
+				}
+			})
+			// write template name and repo url
+			.then(() => {
+				const { templateName, templateUrl, aliasedTemplates } = values;
+				const newAliases = JSON.stringify(Object.assign(aliasedTemplates, { [templateName]: templateUrl }))
+				fs.writeFileSync(configPath, newAliases);
+			})
+			.catch(err => fail(err))
+	);
+}


### PR DESCRIPTION
When creating a new project from a custom template it is now possible to have a mapping from custom template name to template/repo url. So the init command is usable for custom templates as it is for built in templates (even overrides are possible).

The config file ``~/.moleculer-templates.json`` is just a simple mapping where key is the template name and value is the desired template/repo url. The resolution works just like if the templateName was given to the original init command