### PR TITLE
Port to `Buffer.from()`

### DIFF
--- a/src/init/index.js
+++ b/src/init/index.js
@@ -312,7 +312,7 @@ function renderTemplate(skipInterpolation) {
 
 			render(str, metadata, function (err, res) {
 				if (err) return done(err);
-				files[file].contents = new Buffer(res);
+				files[file].contents = Buffer.from(res);
 				next();
 			});
 		}, done);


### PR DESCRIPTION
Requested in https://github.com/moleculerjs/moleculer-cli/pull/14#issuecomment-431551957

I think this is right?

Followed one of the simpler recommendations from the [Node docs](https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/#variant-1-drop-support-for-node-js-4-4-x-and-5-0-0-5-9-x).