### PR TITLE
Fixes #21 Folder exists check skip flag

### DIFF
--- a/src/init/index.js
+++ b/src/init/index.js
@@ -158,6 +158,7 @@ function handler(opts) {
 		// Check target directory
 		.then(() => {
 			if (fs.existsSync(values.projectPath)) {
+                if (templateMeta.promptForProjectOverwrite === false) return;
 				return inquirer.prompt([{
 					type: "confirm",
 					name: "continue",


### PR DESCRIPTION
Added a flag to the generator code to make it so that you can skip the folder exists check when generating services