### PR TITLE
add raw-helper handlebars helper to init

### DIFF
--- a/src/init/index.js
+++ b/src/init/index.js
@@ -69,6 +69,7 @@ Handlebars.registerHelper("if_eq", (a, b, opts) => a === b ? opts.fn(this) : opt
 Handlebars.registerHelper("unless_eq", (a, b, opts) => a === b ? opts.inverse(this) : opts.fn(this));
 Handlebars.registerHelper("if_or", (v1, v2, options) => (v1 || v2) ? options.fn(this) : options.inverse(this));
 Handlebars.registerHelper("if_and", (v1, v2, options) => (v1 && v2) ? options.fn(this) : options.inverse(this));
+Handlebars.registerHelper("raw-helper", (options) => options.fn());
 
 /**
  * Handler for yargs command


### PR DESCRIPTION
add raw-helper from handlebars to init so that complex templates that already use {{}} in their code, like vue templates, will work with init and preserve the code unchanged.

usage:
```
{{{{raw-helper}}}}
{bar}
{{{{/raw-helper}}}}
```
will produce {bar} instead of throwing an exception when creating a project from a template using {{}} in it's codebase.